### PR TITLE
Fix broker keep-alive.

### DIFF
--- a/tests/ping_test.toit
+++ b/tests/ping_test.toit
@@ -56,7 +56,7 @@ class SlowTransport implements mqtt.Transport:
 
   write bytes/ByteArray -> int:
     if should_write_slowly:
-      sleep --ms=100
+      sleep --ms=200
       wrapped_.write bytes[0..1]
       return 1
     else:


### PR DESCRIPTION
Every byte that comes from the client should count as a keep-alive
signal. This means that we need to look at the reader when something
comes in, and not just when a full packet has arrived.