### PR TITLE
Don't try to reuse a connection when reconnecting

### DIFF
--- a/src/full_client.toit
+++ b/src/full_client.toit
@@ -274,9 +274,11 @@ abstract class DefaultReconnectionStrategyBase implements ReconnectionStrategy:
       [--reconnect_transport]
       [--send_connect]
       [--receive_connect_ack]:
-    for i := reuse_connection ? -1 : 0; i < attempt_delays_.size; i++:
+    for i := -1; i < attempt_delays_.size; i++:
       if is_closed: return null
-      if i >= 0:
+      if i == -1 and not reuse_connection:
+        reconnect_transport.call
+      else if i >= 0:
         sleep_duration := attempt_delays_[i]
         closed_signal_.wait --timeout=sleep_duration
         if is_closed: return null

--- a/src/full_client.toit
+++ b/src/full_client.toit
@@ -270,10 +270,11 @@ abstract class DefaultReconnectionStrategyBase implements ReconnectionStrategy:
   Returns whether the broker had a session for this client, otherwise.
   */
   do_connect transport/ActivityMonitoringTransport
+      --reuse_connection/bool=false
       [--reconnect_transport]
       [--send_connect]
       [--receive_connect_ack]:
-    for i := -1; i < attempt_delays_.size; i++:
+    for i := reuse_connection ? -1 : 0; i < attempt_delays_.size; i++:
       if is_closed: return null
       if i >= 0:
         sleep_duration := attempt_delays_[i]
@@ -334,6 +335,7 @@ class DefaultCleanSessionReconnectionStrategy extends DefaultReconnectionStrateg
     // The clean session does not reconnect.
     if not is_initial_connection: throw "INVALID_STATE"
     session_exists := do_connect transport
+        --reuse_connection = is_initial_connection
         --reconnect_transport = reconnect_transport
         --send_connect = send_connect
         --receive_connect_ack = receive_connect_ack
@@ -364,6 +366,7 @@ class DefaultSessionReconnectionStrategy extends DefaultReconnectionStrategyBase
       [--receive_connect_ack]
       [--disconnect]:
     session_exists := do_connect transport
+        --reuse_connection = is_initial_connection
         --reconnect_transport = reconnect_transport
         --send_connect = send_connect
         --receive_connect_ack = receive_connect_ack

--- a/tests/reconnect_close_test.toit
+++ b/tests/reconnect_close_test.toit
@@ -101,9 +101,12 @@ test_no_disconnect_packet create_transport/Lambda --logger/log.Logger:
     activity := get_activity.call
     // We never connected again.
     expect (activity.filter: it[0] == "write" and it[1] is mqtt.ConnectPacket).is_empty
-    // There should be at most 1 reconnect attempt. (In theory there could be a race condition, but
-    // the timeout for trying again is 10s, so that's quite high).
-    expect (activity.filter: it[0] == "reconnect").size <= 1
+    // There should be at most 2 reconnect attempt.
+    // One without delay, when trying to reconnect.
+    // Then another after the first delay (0ms) has elapsed.
+    // The third attempt should only happen after 10s, and the program should have finished
+    // at this point.
+    expect (activity.filter: it[0] == "reconnect").size <= 2
 
 
 /**


### PR DESCRIPTION
If we get into a reconnect state, don't try to reuse the existing connection. There is usually a reason we try to reconnect and it's safer to just let the transport reestablish a fresh connection.