### PR TITLE
Fix race condition

### DIFF
--- a/src/full_client.toit
+++ b/src/full_client.toit
@@ -529,7 +529,7 @@ class Session_:
   /**
   Keeps track of ids that haven't been given to the persistence store yet
     but are in the process of being sent to the broker.
-  Once the sending is done without an exception the id is removed from this
+  Once the sending is done without an exception, the id is removed from this
     set and given to the persistence store.
   Depending on whether it was $ACKED_ or $NOT_ACKED_, the packet is then
     immediately removed from the store again.

--- a/tests/fast_ack_test.toit
+++ b/tests/fast_ack_test.toit
@@ -1,0 +1,105 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import log
+import mqtt
+import mqtt.transport as mqtt
+import mqtt.packets as mqtt
+import monitor
+import net
+
+import .broker_internal
+import .broker_mosquitto
+import .transport
+import .packet_test_client
+
+/**
+Tests that the client can handle acks that arrive fast. That is, where
+  the client is still in the 'send' routine of the transport.
+*/
+main args:
+  test_with_mosquitto := args.contains "--mosquitto"
+  log_level := log.DEBUG_LEVEL
+  logger := log.default.with_level log_level
+
+  run_test := : | create_transport/Lambda | test create_transport --logger=logger
+  if test_with_mosquitto: with_mosquitto --logger=logger run_test
+  else: with_internal_broker --logger=logger run_test
+
+class TestPersistenceStore extends mqtt.MemoryPersistenceStore:
+  added := {}
+  removed := {}
+
+  add packet/mqtt.PersistedPacket -> none:
+    added.add packet.packet-id
+    super packet
+
+  remove_persisted_with_id packet_id/int -> bool:
+    removed.add packet_id
+    return super packet_id
+
+test create_transport/Lambda --logger/log.Logger:
+  persistence_store := TestPersistenceStore
+  id := "persistence_client_id"
+
+  return_from_write := monitor.Channel 1
+  delay_is_active := false
+  create_test_transport := ::
+    test_transport := CallbackTestTransport create_transport.call
+    test_transport.on_after_write = ::
+      if delay_is_active: return_from_write.receive
+    test_transport
+
+  received_ack := monitor.Channel 1
+  read_filter := :: | packet/mqtt.Packet |
+    if packet is mqtt.PubAckPacket:
+      received_ack.send true
+    packet
+
+  with_packet_client create_test_transport
+      --client_id = id
+      --read_filter = read_filter
+      --persistence_store = persistence_store
+      --logger=logger: | client/mqtt.FullClient wait_for_idle/Lambda _ _ |
+
+    print "wait for idle"
+    wait_for_idle.call
+
+    client.publish "not_delayed" "payload".to_byte_array --qos=1
+    received_ack.receive
+    YIELD_COUNT ::= 10
+    YIELD_COUNT.repeat: yield
+    expect persistence_store.is_empty
+    // The ack should have made it to the persistence store.
+    expect persistence_store.is-empty
+    expect_equals 1 persistence_store.added.size
+
+    delay_is_active = true
+    publish_is_done := false
+    task::
+      client.publish "delayed" "payload".to_byte_array --qos=1
+      publish_is_done = true
+    // The delay is *after* we sent the message to the broker.
+    // We expect to get an ack.
+    received_ack.receive
+    // Allow the ack to propagate.
+    YIELD_COUNT.repeat: yield
+    // The publish is still in process.
+    expect_not publish_is_done
+    // At this point the persistence store hasn't received the packet
+    // nor the ack yet as the send routine is still running.
+    expect persistence_store.is-empty
+    expect_equals 1 persistence_store.added.size
+
+    return_from_write.send true
+    YIELD_COUNT.repeat: yield
+    // The publish is now done.
+    expect publish_is_done
+    // The ack should have made it to the persistence store.
+    expect persistence_store.is-empty
+    expect_equals 2 persistence_store.added.size
+    expect_equals 2 persistence_store.removed.size
+
+    delay_is_active = false

--- a/tests/fast_ack_test.toit
+++ b/tests/fast_ack_test.toit
@@ -33,7 +33,7 @@ class TestPersistenceStore extends mqtt.MemoryPersistenceStore:
   removed := {}
 
   add packet/mqtt.PersistedPacket -> none:
-    added.add packet.packet-id
+    added.add packet.packet_id
     super packet
 
   remove_persisted_with_id packet_id/int -> bool:
@@ -73,7 +73,7 @@ test create_transport/Lambda --logger/log.Logger:
     YIELD_COUNT.repeat: yield
     expect persistence_store.is_empty
     // The ack should have made it to the persistence store.
-    expect persistence_store.is-empty
+    expect persistence_store.is_empty
     expect_equals 1 persistence_store.added.size
 
     delay_is_active = true
@@ -90,7 +90,7 @@ test create_transport/Lambda --logger/log.Logger:
     expect_not publish_is_done
     // At this point the persistence store hasn't received the packet
     // nor the ack yet as the send routine is still running.
-    expect persistence_store.is-empty
+    expect persistence_store.is_empty
     expect_equals 1 persistence_store.added.size
 
     return_from_write.send true
@@ -98,7 +98,7 @@ test create_transport/Lambda --logger/log.Logger:
     // The publish is now done.
     expect publish_is_done
     // The ack should have made it to the persistence store.
-    expect persistence_store.is-empty
+    expect persistence_store.is_empty
     expect_equals 2 persistence_store.added.size
     expect_equals 2 persistence_store.removed.size
 

--- a/tests/transport.toit
+++ b/tests/transport.toit
@@ -282,17 +282,23 @@ class CallbackTestTransport implements mqtt.Transport:
   on_reconnect /Lambda? := null
   on_disconnect /Lambda? := null
   on_write /Lambda? := null
+  on_after_write /Lambda? := null
   on_read /Lambda? := null
+  on_after_read /Lambda? := null
 
   constructor .wrapped_:
 
   write bytes/ByteArray -> int:
     if on_write: on_write.call bytes
-    return wrapped_.write bytes
+    result := wrapped_.write bytes
+    if on_after_write: on_after_write.call bytes result
+    return result
 
   read -> ByteArray?:
     if on_read: return on_read.call wrapped_
-    return wrapped_.read
+    result := wrapped_.read
+    if on_after_read: on_after_read.call result
+    return result
 
   close -> none: wrapped_.close
 


### PR DESCRIPTION
The broker was able to respond faster than we added the qos1 packet to the persistence store.

This lead missed acks (`unmatched packet id: ...`) and eventually stalled the pipeline since the client had too many unacked packets.