### PR TITLE
Fix bad wrap-around.

### DIFF
--- a/examples/package.lock
+++ b/examples/package.lock
@@ -6,5 +6,6 @@ packages:
     path: ..
   toit-cert-roots:
     url: github.com/toitware/toit-cert-roots
+    name: certificate_roots
     version: 1.2.0
     hash: b108d257000e7ac21ebefb03e1111f9dfa75bc02

--- a/src/full_client.toit
+++ b/src/full_client.toit
@@ -670,7 +670,7 @@ class Session_:
       next-packet-id_ = (candidate + 1) & ((1 << PublishPacket.ID-BIT-SIZE) - 1)
 
       // Message ID 0 is reserved as invalid.
-      if next-packet-id_ == 0: next-packet-id_ = 1
+      if candidate == 0: continue
       // If we are waiting for an ACK of the candidate id, pick a different one.
       if persistence-store_.get candidate: continue
       return candidate

--- a/src/full_client.toit
+++ b/src/full_client.toit
@@ -668,6 +668,9 @@ class Session_:
     while true:
       candidate := next-packet-id_
       next-packet-id_ = (candidate + 1) & ((1 << PublishPacket.ID-BIT-SIZE) - 1)
+
+      // Message ID 0 is reserved as invalid.
+      if next-packet-id_ == 0: next-packet-id_ = 1
       // If we are waiting for an ACK of the candidate id, pick a different one.
       if persistence-store_.get candidate: continue
       return candidate

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a Zero-Clause BSD license that can
 # be found in the tests/LICENSE file.
 
-file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*_test.toit")
+file(GLOB TESTS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*_test.toit" "*-test.toit")
 
 set(TOIT_EXEC "toit.run${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "The executable used to run the tests")
 set(TPKG_EXEC "toit.pkg${CMAKE_EXECUTABLE_SUFFIX}" CACHE FILEPATH "The executable used to install the packages")

--- a/tests/wrap-around-test.toit
+++ b/tests/wrap-around-test.toit
@@ -1,0 +1,47 @@
+// Copyright (C) 2022 Toitware ApS.
+// Use of this source code is governed by a Zero-Clause BSD license that can
+// be found in the tests/LICENSE file.
+
+import expect show *
+import log
+import monitor
+import mqtt
+import mqtt.transport as mqtt
+import net
+
+import .broker-internal
+import .broker-mosquitto
+import .transport
+
+test create-transport/Lambda --logger/log.Logger:
+  transport /mqtt.Transport := create-transport.call
+  client := mqtt.Client --transport=transport --logger=logger
+  options := mqtt.SessionOptions --client-id="test_wrap_around"
+  client.start --options=options
+
+  client.client_.session_.next-packet-id_ = 0xFFFA
+
+  done := monitor.Latch
+
+  foo-counter := 0
+  client.subscribe "foo":: foo-counter++
+  client.subscribe "done":: done.set true
+
+  iterations := 20
+  iterations.repeat:
+    client.publish "foo" "msg" --qos=1
+
+  client.publish "done" "done".to-byte-array --qos=0
+  done.get
+
+  expect-equals 20 iterations
+  client.close
+
+main args:
+  test-with-mosquitto := args.contains "--mosquitto"
+  log-level := log.ERROR-LEVEL
+  logger := log.default.with-level log-level
+
+  run-test := : | create-transport/Lambda | test create-transport --logger=logger
+  if test-with-mosquitto: with-mosquitto --logger=logger run-test
+  else: with-internal-broker --logger=logger run-test


### PR DESCRIPTION
IDs are 16 bits, but ID 0 is not allowed (reserved for invalid messages). We can't just wrap-around, but must exclude 0.
