### PR TITLE
Avoid leaking network clients.

### DIFF
--- a/src/tcp.toit
+++ b/src/tcp.toit
@@ -100,10 +100,12 @@ class ReconnectingTransport_ extends TcpTransport:
     port_ = port
     open_ = net-open
     super.from-subclass_
+    success := false
     try:
       reconnect
-    finally: | is-exception _ |
-      if is-exception: close
+      success = true
+    finally:
+      if not success: close
 
   close -> none:
     super

--- a/src/tcp.toit
+++ b/src/tcp.toit
@@ -100,7 +100,10 @@ class ReconnectingTransport_ extends TcpTransport:
     port_ = port
     open_ = net-open
     super.from-subclass_
-    reconnect
+    try:
+      reconnect
+    finally: | is-exception _ |
+      if is-exception: close
 
   close -> none:
     super


### PR DESCRIPTION
If the `reconnect` fails in the constructor we weren't cleaning up.